### PR TITLE
Mono support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: csharp
 solution: src/GitTools.Testing.sln
-sudo: true
+sudo: false
 install:
-  - sudo nuget update -self
+  # - sudo nuget update -self
   - nuget restore src/GitTools.Testing.sln
   - nuget install xunit.runner.console -Version 2.1.0 -OutputDirectory ./src/packages
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: csharp
+solution: src/GitTools.Testing.sln
+sudo: true
+install:
+  - sudo nuget update -self
+  - nuget restore src/GitTools.Testing.sln
+  - nuget install NUnit.Runners -Version 3.2.1 -OutputDirectory ./src/packages
+script:
+  - xbuild ./src/GitTools.Testing.sln /property:Configuration="Debug" /verbosity:detailed
+  - mono --debug --runtime=v4.0.30319 ./src/packages/NUnit.ConsoleRunner.3.2.1/tools/nunit3-console.exe ./src/GitTools.Testing.Tests/bin/Debug/GitTools.Testing.Tests.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: true
 install:
   - sudo nuget update -self
   - nuget restore src/GitTools.Testing.sln
-  - nuget install NUnit.Runners -Version 3.2.1 -OutputDirectory ./src/packages
+  - nuget install xunit.runner.console -Version 2.1.0 -OutputDirectory ./src/packages
 script:
   - xbuild ./src/GitTools.Testing.sln /property:Configuration="Debug" /verbosity:detailed
-  - mono --debug --runtime=v4.0.30319 ./src/packages/NUnit.ConsoleRunner.3.2.1/tools/nunit3-console.exe ./src/GitTools.Testing.Tests/bin/Debug/GitTools.Testing.Tests.dll
+  - mono --debug --runtime=v4.0.30319 ./src/packages/xunit.runner.console.2.1.0/tools/xunit.console.exe ./src/GitTools.Testing.Tests/bin/Debug/GitTools.Testing.Tests.dll

--- a/src/GitTools.Testing.Tests/GitTools.Testing.Tests.csproj
+++ b/src/GitTools.Testing.Tests/GitTools.Testing.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GitTools.Testing.Tests</RootNamespace>
     <AssemblyName>GitTools.Testing.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/src/GitTools.Testing.Tests/packages.config
+++ b/src/GitTools.Testing.Tests/packages.config
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
-  <package id="xunit.core" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net452" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/src/GitTools.Testing.sln
+++ b/src/GitTools.Testing.sln
@@ -1,10 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".configs", ".configs", "{EB4A8A14-F0E1-424C-84C2-8FF29E4B62FA}"
 	ProjectSection(SolutionItems) = preProject
+		..\.travis.yml = ..\.travis.yml
 		..\appveyor.yml = ..\appveyor.yml
 		GitTools.Testing.nuspec = GitTools.Testing.nuspec
 		..\GitVersionConfig.yaml = ..\GitVersionConfig.yaml

--- a/src/GitTools.Testing/Fixtures/BaseGitFlowRepositoryFixture.cs
+++ b/src/GitTools.Testing/Fixtures/BaseGitFlowRepositoryFixture.cs
@@ -34,7 +34,7 @@ namespace GitTools.Testing
         {
             var randomFile = Path.Combine(Repository.Info.WorkingDirectory, Guid.NewGuid().ToString());
             File.WriteAllText(randomFile, string.Empty);
-            Repository.Stage(randomFile);
+            Commands.Stage(Repository, randomFile);
 
             initialMasterAction(Repository);
 

--- a/src/GitTools.Testing/GitTestExtensions.cs
+++ b/src/GitTools.Testing/GitTestExtensions.cs
@@ -46,7 +46,7 @@ namespace GitTools.Testing
             var contents = Guid.NewGuid().ToString().PadRight(totalWidth, '.');
             File.WriteAllText(randomFile, contents);
 
-            repository.Stage(randomFile);
+            Commands.Stage(repository, randomFile);
 
             return repository.Commit(string.Format("Test Commit for file '{0}' - {1}", relativeFileName, commitMessage),
                 Generate.SignatureNow(), Generate.SignatureNow());

--- a/src/GitTools.Testing/GitTools.Testing.csproj
+++ b/src/GitTools.Testing/GitTools.Testing.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props')" />
+  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -43,8 +43,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="LibGit2Sharp, Version=0.22.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
-      <HintPath>..\packages\LibGit2Sharp.0.22.0\lib\net40\LibGit2Sharp.dll</HintPath>
+    <Reference Include="LibGit2Sharp, Version=0.23.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
+      <HintPath>..\packages\LibGit2Sharp.0.23.0-pre20150419160303\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -80,7 +80,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.129\build\LibGit2Sharp.NativeBinaries.props'))" />
+    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.137\build\LibGit2Sharp.NativeBinaries.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/GitTools.Testing/GitTools.Testing.csproj
+++ b/src/GitTools.Testing/GitTools.Testing.csproj
@@ -26,7 +26,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\GitTools.Testing.xml</DocumentationFile>
-    <NoWarn>1591</NoWarn>
+    <NoWarn>1591,414</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>

--- a/src/GitTools.Testing/packages.config
+++ b/src/GitTools.Testing/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="LibGit2Sharp" version="0.22.0" targetFramework="net40" />
-  <package id="LibGit2Sharp.NativeBinaries" version="1.0.129" targetFramework="net40" />
+  <package id="LibGit2Sharp" version="0.23.0-pre20150419160303" targetFramework="net40" />
+  <package id="LibGit2Sharp.NativeBinaries" version="1.0.137" targetFramework="net40" />
   <package id="LibLog" version="4.2.5" targetFramework="net40" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
This PR adds a Travis build to ensure Linux/Mono compatibility and upgrades `LibGit2Sharp` to [version `0.23.0-pre20150419160303`](https://www.nuget.org/packages/LibGit2Sharp/0.23.0-pre20150419160303) so we get the fixes in libgit2/libgit2sharp#1298. It would be nice to get this merged and pre-released on NuGet, so I can go on to update GitTools.Core and GitVersion as well.
