### PR TITLE
Closes #12 - Switch to libgit2sharp.

### DIFF
--- a/src/GitTools.Testing.Tests/GitTools.Testing.Tests.csproj
+++ b/src/GitTools.Testing.Tests/GitTools.Testing.Tests.csproj
@@ -26,24 +26,16 @@
     <PackageReference Include="xunit.core" Version="2.3.0-beta3-build3705" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
     <PackageReference Include="xunit.runner.console" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="LibGit2Sharp" Version="0.25.0-preview-0033" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <PackageReference Include="LibGit2Sharp" Version="0.24.0" />
-  </ItemGroup>
-
-  <!-- TODO: Unify this dependency with the LibGit2Sharp NuGet dependency
-    when the portable NuGet has been officially released. -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
-    <PackageReference Include="LibGit2Sharp.Portable" Version="0.24.10" />
-  </ItemGroup>
+  </ItemGroup> 
 
   <ItemGroup>
     <ProjectReference Include="..\GitTools.Testing\GitTools.Testing.csproj" />
-  </ItemGroup>
+  </ItemGroup> 
 
   <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
+ 
 </Project>

--- a/src/GitTools.Testing.sln
+++ b/src/GitTools.Testing.sln
@@ -1,13 +1,12 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".configs", ".configs", "{EB4A8A14-F0E1-424C-84C2-8FF29E4B62FA}"
 	ProjectSection(SolutionItems) = preProject
 		..\.travis.yml = ..\.travis.yml
 		..\appveyor.yml = ..\appveyor.yml
-		GitTools.Testing.nuspec = GitTools.Testing.nuspec
 		..\GitVersionConfig.yaml = ..\GitVersionConfig.yaml
 		..\README.md = ..\README.md
 	EndProjectSection

--- a/src/GitTools.Testing/GitTools.Testing.csproj
+++ b/src/GitTools.Testing/GitTools.Testing.csproj
@@ -19,16 +19,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <PackageReference Include="LibGit2Sharp" Version="0.24.0" />
-  </ItemGroup>
-
-  <!-- TODO: Unify this dependency with the LibGit2Sharp NuGet dependency
-    when the portable NuGet has been officially released. -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="LibGit2Sharp.Portable" Version="0.24.10" />
+    <PackageReference Include="LibGit2Sharp" Version="0.25.0-preview-0033" />
+  </ItemGroup> 
+ 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">  
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Removes libgit2sharp.portable package in favour of updated libgit2sharp package.